### PR TITLE
Fix overwriting GHSH and GHVH setlists

### DIFF
--- a/haskell/packages/onyx-lib/src/Onyx/Neversoft/Metadata.hs
+++ b/haskell/packages/onyx-lib/src/Onyx/Neversoft/Metadata.hs
@@ -109,6 +109,7 @@ showTextPakQBQS :: TextPakQB -> (BL.ByteString, BL.ByteString)
 showTextPakQBQS contents = let
   qbLists = do
     songlistID <- nubOrd $ map songArrayID $ textPakSongStructs contents
+    guard $ songlistID /= qbKeyCRC "gh4_2_songlist" && songlistID /= qbKeyCRC "gh4_3_songlist" -- We only want the metadata updates, not overwrite the setlists
     return $ QBSectionArray songlistID (textPakFileKey contents) $ QBArrayOfQbKey $ do
       struct <- textPakSongStructs contents
       guard $ songArrayID struct == songlistID


### PR DESCRIPTION
Currently when adding the missing Smash Hits and Van Halen exports, Onyx is overwriting the on-disc setlist for these two games with the order in which the props were defined. These are not alphabetical so it's causing the exports to have a wonky order. This PR prevents Onyx from adding the re-made SH and VH setlists to the song cache so the game will use the one defined on-disc instead with the proper order.